### PR TITLE
Correção do link Try Clojure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 ## Leitura
   - [Learn Clojure in Y minutes](https://learnxinyminutes.com/docs/clojure/)
-  - [Try Clojure (online REPL)](http://www.4clojure.com/)
+  - [Try Clojure (online REPL)](http://www.tryclj.com/)
   - [CLOJURE for the BRAVE and TRUE](http://www.braveclojure.com/getting-started/)
   - [4 Clojure](http://www.4clojure.com)
   - [Clojure Koans](http://clojurekoans.com/)


### PR DESCRIPTION
Link do Try Clojure apontava para o endereço http://www.4clojure.com.

Foi alterado para apontar para http://www.tryclj.com/